### PR TITLE
Seek block when starts a ScanKey (#1828)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -412,10 +412,6 @@ namespace config {
     // and the tablet will be marked as bad, so that FE will try to repair it.
     CONF_Bool(auto_recover_index_loading_failure, "false");
 
-    // This configuration is used to recover compaction under the corner case.
-    // If this configuration is set to true, block will seek position.
-    CONF_Bool(block_seek_position, "false");
-
     // the max client cache number per each host
     // There are variety of client cache in BE, but currently we use the
     // same cache size configuration.

--- a/be/src/olap/segment_reader.cpp
+++ b/be/src/olap/segment_reader.cpp
@@ -292,6 +292,15 @@ OLAPStatus SegmentReader::seek_to_block(
     *next_block_id = _next_block_id;
     *eof = _eof;
 
+    // Must seek block when starts a ScanKey.
+    // In Doris, one block has 1024 rows.
+    // 1. If the previous ScanKey scan rows multiple blocks,
+    //    and also the final block has 1024 rows just right.
+    // 2. The current ScanKey scan rows with number less than one block.
+    // Under the two conditions, if not seek block, the position
+    // of prefix shortkey columns is wrong.
+    _need_to_seek_block = true;
+
     return OLAP_SUCCESS;
 }
 
@@ -837,7 +846,7 @@ OLAPStatus SegmentReader::_create_reader(size_t* buffer_size) {
 
 OLAPStatus SegmentReader::_seek_to_block_directly(
         int64_t block_id, const std::vector<uint32_t>& cids) {
-    if (!config::block_seek_position && _at_block_start && block_id == _current_block_id) {
+    if (!_need_to_seek_block && block_id == _current_block_id) {
         // no need to execute seek
         return OLAP_SUCCESS;
     }
@@ -866,7 +875,7 @@ OLAPStatus SegmentReader::_seek_to_block_directly(
         }
     }
     _current_block_id = block_id;
-    _at_block_start = true;
+    _need_to_seek_block = false;
     return OLAP_SUCCESS;
 }
 
@@ -938,7 +947,7 @@ OLAPStatus SegmentReader::_load_to_vectorized_row_batch(
     if (size == _num_rows_in_block) {
         _current_block_id++;
     } else {
-        _at_block_start = false;
+        _need_to_seek_block = true;
     }
 
     _stats->blocks_load++;

--- a/be/src/olap/segment_reader.h
+++ b/be/src/olap/segment_reader.h
@@ -287,9 +287,9 @@ private:
 
     bool _eof;                             // eof标志
 
-    // If this field is false, client must to call seek_to_block before
+    // If this field is true, client must to call seek_to_block before
     // calling get_block.
-    bool _at_block_start = false;
+    bool _need_to_seek_block = true;
 
     int64_t _end_block;                           // 本次读取的结束块
     int64_t _current_block_id = 0;                       // 当前读取到的块


### PR DESCRIPTION
In Doris, one block has 1024 rows.
1. If the previous ScanKey scan rows multiple blocks,
   and also the final block has 1024 rows just right.
2. The current ScanKey scan rows with number less than one block.
Under the two conditions, if not seek block, the position of prefix shortkey columns is wrong.